### PR TITLE
Fix failing tests

### DIFF
--- a/handlers_test.go
+++ b/handlers_test.go
@@ -36,18 +36,9 @@ func TestSubmitDailyReport(t *testing.T) {
 		mockEsaClient.EXPECT().CreatePost(testText).Return(mockPost, nil)
 
 		// リクエスト作成
-		req := mcp.CallToolRequest{
-			Params: struct {
-				Name      string                 `json:"name"`
-				Arguments map[string]interface{} `json:"arguments,omitempty"`
-				Meta      *struct {
-					ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
-				} `json:"_meta,omitempty"`
-			}{
-				Arguments: map[string]interface{}{
-					"text": testText,
-				},
-			},
+		req := mcp.CallToolRequest{}
+		req.Params.Arguments = map[string]any{
+			"text": testText,
 		}
 		// テスト対象の関数を実行
 		result, err := submitDailyReportWithTime(context.TODO(), req, mockEsaClient, fixedTime)
@@ -92,18 +83,9 @@ func TestSubmitDailyReport(t *testing.T) {
 		mockEsaClient.EXPECT().UpdatePost(existingPost, testText).Return(updatedPost, nil)
 
 		// リクエスト作成
-		req := mcp.CallToolRequest{
-			Params: struct {
-				Name      string                 `json:"name"`
-				Arguments map[string]interface{} `json:"arguments,omitempty"`
-				Meta      *struct {
-					ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
-				} `json:"_meta,omitempty"`
-			}{
-				Arguments: map[string]interface{}{
-					"text": testText,
-				},
-			},
+		req := mcp.CallToolRequest{}
+		req.Params.Arguments = map[string]any{
+			"text": testText,
 		}
 
 		// テスト対象の関数を実行
@@ -134,18 +116,9 @@ func TestSubmitDailyReport(t *testing.T) {
 		mockEsaClient.EXPECT().SearchPostByCategory("日報/2025/05/03").Return(nil, errors.New("API接続エラー"))
 
 		// リクエスト作成
-		req := mcp.CallToolRequest{
-			Params: struct {
-				Name      string                 `json:"name"`
-				Arguments map[string]interface{} `json:"arguments,omitempty"`
-				Meta      *struct {
-					ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
-				} `json:"_meta,omitempty"`
-			}{
-				Arguments: map[string]interface{}{
-					"text": "テスト内容",
-				},
-			},
+		req := mcp.CallToolRequest{}
+		req.Params.Arguments = map[string]any{
+			"text": "テスト内容",
 		}
 		// テスト対象の関数を実行
 		_, err := submitDailyReportWithTime(context.TODO(), req, mockEsaClient, fixedTime)
@@ -176,18 +149,9 @@ func TestSubmitDailyReport(t *testing.T) {
 		mockEsaClient.EXPECT().CreatePost(expectedText).Return(mockPost, nil)
 
 		// リクエスト作成
-		req := mcp.CallToolRequest{
-			Params: struct {
-				Name      string                 `json:"name"`
-				Arguments map[string]interface{} `json:"arguments,omitempty"`
-				Meta      *struct {
-					ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
-				} `json:"_meta,omitempty"`
-			}{
-				Arguments: map[string]interface{}{
-					"text": inputText,
-				},
-			},
+		req := mcp.CallToolRequest{}
+		req.Params.Arguments = map[string]any{
+			"text": inputText,
 		}
 
 		// テスト対象の関数を実行
@@ -207,18 +171,9 @@ func TestSubmitDailyReport(t *testing.T) {
 		mockEsaClient := NewMockEsaClientInterface(t)
 
 		// text引数が文字列でない場合
-		req := mcp.CallToolRequest{
-			Params: struct {
-				Name      string                 `json:"name"`
-				Arguments map[string]interface{} `json:"arguments,omitempty"`
-				Meta      *struct {
-					ProgressToken mcp.ProgressToken `json:"progressToken,omitempty"`
-				} `json:"_meta,omitempty"`
-			}{
-				Arguments: map[string]interface{}{
-					"text": 123, // 文字列ではなく数値
-				},
-			},
+		req := mcp.CallToolRequest{}
+		req.Params.Arguments = map[string]any{
+			"text": 123, // 文字列ではなく数値
 		}
 
 		// テスト対象の関数を実行


### PR DESCRIPTION
## Summary
- fix compilation errors in handlers tests by using `mcp.CallToolRequest` directly

## Testing
- `go test ./...`
