### PR TITLE
esa.io検索機能の一般化

### DIFF
--- a/docs/onetime/20250531_improve_search_parameters.md
+++ b/docs/onetime/20250531_improve_search_parameters.md
@@ -61,7 +61,7 @@ type SearchOption func(*searchConfig)
 
 func WithCategory(category string) SearchOption
 func WithTags(tags ...string) SearchOption
-func WithDateRange(from, to time.Time) SearchOption
+func WithDateRange(field string, from, to time.Time) SearchOption
 ```
 - 利点: 
   - Go言語らしいイディオム
@@ -97,13 +97,13 @@ type SearchOption func(*searchConfig)
 ```go
 func WithCategory(category string) SearchOption {
     return func(c *searchConfig) {
-        c.query += fmt.Sprintf(" category:%s", category)
+        c.categoryQuery = fmt.Sprintf("category:%s", category)
     }
 }
 
 func WithCategoryExact(category string) SearchOption {
     return func(c *searchConfig) {
-        c.query += fmt.Sprintf(" on:%s", category)
+        c.categoryQuery = fmt.Sprintf("on:%s", category)
     }
 }
 

--- a/docs/onetime/20250531_improve_search_parameters.md
+++ b/docs/onetime/20250531_improve_search_parameters.md
@@ -82,11 +82,12 @@ func SearchWithQuery(query string, page, perPage int) (*EsaSearchResult, error)
 ### 1. 基本構造の定義
 ```go
 type searchConfig struct {
-    query      string
-    page       int
-    perPage    int
-    sort       string
-    order      string
+    query         string
+    categoryQuery string // カテゴリー検索専用フィールド（排他的）
+    page          int
+    perPage       int
+    sort          string
+    order         string
 }
 
 type SearchOption func(*searchConfig)
@@ -179,6 +180,26 @@ results, err := client.Search(
 // 完全一致でのカテゴリー検索
 results, err := client.Search(
     WithCategoryExact("日報/2024/12/20"),
+)
+```
+
+### カテゴリーオプションの排他的動作
+
+カテゴリー検索オプション（`WithCategory`、`WithCategoryExact`、`WithCategoryPrefix`）は排他的に動作します。複数指定した場合、最後に指定されたオプションが有効となります。
+
+```go
+// 最後のWithCategoryが有効になる
+results, err := client.Search(
+    WithCategoryExact("日報/2024/12/20"),  // この指定は無効
+    WithCategoryPrefix("日報/2024"),       // この指定は無効
+    WithCategory("日報"),                  // これが有効（category:日報）
+)
+
+// 他の検索オプションと組み合わせ可能
+results, err := client.Search(
+    WithCategory("日報"),       // カテゴリー検索
+    WithTags("golang", "mcp"),  // タグ検索（両方適用される）
+    WithUser("test_user"),      // ユーザー検索（適用される）
 )
 ```
 

--- a/docs/onetime/20250531_improve_search_parameters.md
+++ b/docs/onetime/20250531_improve_search_parameters.md
@@ -1,0 +1,208 @@
+# esa.io検索機能の一般化
+
+## 背景
+
+現在の`SearchPostByCategory`メソッドは日報検索に特化しており、以下の制限があった：
+- カテゴリーの部分一致検索のみ対応
+- 日付による絞り込み未対応
+- タグやユーザーによる検索未対応
+- ページネーション未対応
+
+esa.io APIは豊富な検索オプションを提供しているため、これらを活用できるよう検索機能を一般化する必要がある。
+
+## esa.io API仕様の確認
+
+### 検索エンドポイント
+- URL: `https://api.esa.io/v1/teams/:team_name/posts`
+- メソッド: GET
+- 認証: Bearer トークン
+
+### 利用可能な検索オプション
+1. **基本検索**
+   - キーワード検索: `help`
+   - 完全一致: `"exact phrase"`
+   - AND検索: `keyword1 keyword2`
+   - OR検索: `keyword1 OR keyword2`
+   - 除外: `-keyword`
+
+2. **カテゴリー検索**
+   - 部分一致: `category:日報`
+   - 前方一致: `in:日報/2024`
+   - 完全一致: `on:日報/2024/12/20`
+
+3. **その他の検索条件**
+   - タグ: `tag:golang` or `#golang`
+   - ユーザー: `user:screen_name` or `@screen_name`
+   - 日付範囲: `created:>2024-01-01`, `updated:<2024-12-31`
+   - ステータス: `wip:true`, `starred:true`
+
+4. **ソートとページネーション**
+   - ソート: `sort=updated`, `order=desc`
+   - ページング: `page=1`, `per_page=50` (最大100)
+
+## 設計案の検討
+
+### 案1: 検索クエリビルダーパターン
+```go
+type SearchQuery struct {
+    Keywords    []string
+    Category    string
+    CategoryOp  string // "partial", "prefix", "exact"
+    Tags        []string
+    // ...
+}
+```
+- 利点: 構造が明確
+- 欠点: 拡張時に構造体の変更が必要
+
+### 案2: 機能的オプションパターン（採用）
+```go
+type SearchOption func(*searchConfig)
+
+func WithCategory(category string) SearchOption
+func WithTags(tags ...string) SearchOption
+func WithDateRange(from, to time.Time) SearchOption
+```
+- 利点: 
+  - Go言語らしいイディオム
+  - 後方互換性を保ちやすい
+  - 必要なオプションのみ指定可能
+  - 将来の拡張が容易
+- 欠点: 初見では理解しづらい可能性
+
+### 案3: 生のクエリ文字列
+```go
+func SearchWithQuery(query string, page, perPage int) (*EsaSearchResult, error)
+```
+- 利点: 最も柔軟
+- 欠点: 型安全性が低い、検証が困難
+
+## 実装計画
+
+### 1. 基本構造の定義
+```go
+type searchConfig struct {
+    query      string
+    page       int
+    perPage    int
+    sort       string
+    order      string
+}
+
+type SearchOption func(*searchConfig)
+```
+
+### 2. オプション関数の実装
+```go
+func WithCategory(category string) SearchOption {
+    return func(c *searchConfig) {
+        c.query += fmt.Sprintf(" category:%s", category)
+    }
+}
+
+func WithCategoryExact(category string) SearchOption {
+    return func(c *searchConfig) {
+        c.query += fmt.Sprintf(" on:%s", category)
+    }
+}
+
+func WithTags(tags ...string) SearchOption {
+    return func(c *searchConfig) {
+        for _, tag := range tags {
+            c.query += fmt.Sprintf(" tag:%s", tag)
+        }
+    }
+}
+
+func WithDateRange(field string, from, to time.Time) SearchOption {
+    return func(c *searchConfig) {
+        if !from.IsZero() {
+            c.query += fmt.Sprintf(" %s:>%s", field, from.Format("2006-01-02"))
+        }
+        if !to.IsZero() {
+            c.query += fmt.Sprintf(" %s:<%s", field, to.Format("2006-01-02"))
+        }
+    }
+}
+
+func WithPagination(page, perPage int) SearchOption {
+    return func(c *searchConfig) {
+        c.page = page
+        c.perPage = perPage
+    }
+}
+```
+
+### 3. 汎用検索メソッド
+```go
+func (c *EsaClient) Search(options ...SearchOption) (*EsaSearchResult, error) {
+    config := &searchConfig{
+        page:    1,
+        perPage: 20, // APIのデフォルト
+        order:   "desc",
+    }
+    
+    for _, opt := range options {
+        opt(config)
+    }
+    
+    // URLの構築とAPIリクエスト
+    // ...
+}
+```
+
+### 4. 既存メソッドのリファクタリング
+```go
+func (c *EsaClient) SearchPostByCategory(category string) (*EsaPost, error) {
+    result, err := c.Search(
+        WithCategory(category),
+        WithPagination(1, 1),
+    )
+    // 既存のロジックを維持
+}
+```
+
+## 使用例
+
+```go
+// 日報検索（既存の使い方）
+post, err := client.SearchPostByCategory("日報/2024/12/20")
+
+// 汎用検索の例
+results, err := client.Search(
+    WithCategory("日報"),
+    WithDateRange("created", time.Date(2024, 12, 1, 0, 0, 0, 0, time.UTC), time.Now()),
+    WithTags("golang", "mcp"),
+    WithPagination(1, 50),
+)
+
+// 完全一致でのカテゴリー検索
+results, err := client.Search(
+    WithCategoryExact("日報/2024/12/20"),
+)
+```
+
+## テスト計画
+
+1. **APIリクエストの検証**
+   - 正しいURLが構築されるか
+   - クエリパラメータが適切にエンコードされるか
+   - ヘッダーが正しく設定されるか
+
+2. **オプションの組み合わせテスト**
+   - 複数のオプションが正しく適用されるか
+   - クエリ文字列が正しく結合されるか
+
+3. **エラーハンドリング**
+   - APIエラーレスポンスの処理
+   - ネットワークエラーの処理
+
+4. **後方互換性の確認**
+   - 既存のSearchPostByCategoryが同じ動作を維持するか
+
+## 今後の拡張可能性
+
+- ソート条件の追加（stars, comments等）
+- 高度な検索演算子のサポート（括弧、複雑なOR条件）
+- 検索結果のキャッシング
+- 全ページ取得のヘルパー関数

--- a/esa_client.go
+++ b/esa_client.go
@@ -129,7 +129,7 @@ func (c *EsaClient) Search(options ...SearchOption) (*EsaSearchResult, error) {
 	}
 
 	// URLの構築
-	apiURL := fmt.Sprintf("%s%s", esaAPIBaseURL, fmt.Sprintf(esaPostsEndpoint, c.config.TeamName))
+	apiURL := fmt.Sprintf("%s"+esaPostsEndpoint, esaAPIBaseURL, c.config.TeamName)
 	
 	// クエリパラメータの構築
 	params := make(map[string]string)
@@ -206,7 +206,7 @@ func (c *EsaClient) CreatePost(text string) (*EsaPost, error) {
 	title := "日報"
 	var tags []string
 
-	url := fmt.Sprintf("%s%s", esaAPIBaseURL, fmt.Sprintf(esaPostsEndpoint, c.config.TeamName))
+	url := fmt.Sprintf("%s"+esaPostsEndpoint, esaAPIBaseURL, c.config.TeamName)
 
 	// リクエストボディの作成
 	type postRequest struct {
@@ -270,7 +270,7 @@ func (c *EsaClient) CreatePost(text string) (*EsaPost, error) {
 
 // UpdatePost は既存の投稿を更新する
 func (c *EsaClient) UpdatePost(existingPost *EsaPost, text string) (*EsaPost, error) {
-	url := fmt.Sprintf("%s%s", esaAPIBaseURL, fmt.Sprintf(esaPostEndpoint, c.config.TeamName, existingPost.Number))
+	url := fmt.Sprintf("%s"+esaPostEndpoint, esaAPIBaseURL, c.config.TeamName, existingPost.Number)
 
 	// リクエストボディの作成
 	type patchRequest struct {

--- a/esa_client.go
+++ b/esa_client.go
@@ -6,12 +6,26 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"time"
 )
 
+// searchConfig は検索オプションを保持する構造体
+type searchConfig struct {
+	query   string
+	page    int
+	perPage int
+	sort    string
+	order   string
+}
+
+// SearchOption は検索設定を変更する関数型
+type SearchOption func(*searchConfig)
+
 // EsaClientInterface はesa.ioとの通信を担当するインターフェース
 type EsaClientInterface interface {
+	Search(options ...SearchOption) (*EsaSearchResult, error)
 	SearchPostByCategory(category string) (*EsaPost, error)
 	CreatePost(text string) (*EsaPost, error)
 	UpdatePost(existingPost *EsaPost, text string) (*EsaPost, error)
@@ -66,11 +80,75 @@ func ConfigFromEnv() EsaConfig {
 
 // SearchPostByCategory はカテゴリから投稿を検索する
 func (c *EsaClient) SearchPostByCategory(category string) (*EsaPost, error) {
-	// 検索クエリの構築
-	url := fmt.Sprintf("https://api.esa.io/v1/teams/%s/posts?q=category:%s", c.config.TeamName, category)
+	// Searchメソッドを使用
+	result, err := c.Search(
+		WithCategory(category),
+		WithPagination(1, 1),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// 検索結果の処理
+	if result.TotalCount == 0 {
+		// 投稿が存在しない
+		return nil, nil
+	} else if result.TotalCount > 1 {
+		// 複数の投稿が存在する
+		return nil, errors.New("複数の日報が存在します")
+	}
+
+	// 最新の投稿を返す
+	return &result.Posts[0], nil
+}
+
+// Search は汎用的な検索を実行する
+func (c *EsaClient) Search(options ...SearchOption) (*EsaSearchResult, error) {
+	// デフォルト設定
+	config := &searchConfig{
+		page:    1,
+		perPage: 20, // APIのデフォルト値
+		sort:    "updated",
+		order:   "desc",
+	}
+
+	// オプションを適用
+	for _, opt := range options {
+		opt(config)
+	}
+
+	// URLの構築
+	apiURL := fmt.Sprintf("https://api.esa.io/v1/teams/%s/posts", c.config.TeamName)
+	
+	// クエリパラメータの構築
+	params := make(map[string]string)
+	if config.query != "" {
+		params["q"] = config.query
+	}
+	if config.page > 0 {
+		params["page"] = fmt.Sprintf("%d", config.page)
+	}
+	if config.perPage > 0 {
+		params["per_page"] = fmt.Sprintf("%d", config.perPage)
+	}
+	if config.sort != "" {
+		params["sort"] = config.sort
+	}
+	if config.order != "" {
+		params["order"] = config.order
+	}
+
+	// クエリパラメータをURLに追加
+	if len(params) > 0 {
+		values := url.Values{}
+		for key, value := range params {
+			values.Add(key, value)
+		}
+		apiURL += "?" + values.Encode()
+	}
 
 	// リクエストの作成
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest("GET", apiURL, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -97,17 +175,7 @@ func (c *EsaClient) SearchPostByCategory(category string) (*EsaPost, error) {
 		return nil, fmt.Errorf("検索結果の解析に失敗: %w", err)
 	}
 
-	// 検索結果の処理
-	if searchResult.TotalCount == 0 {
-		// 投稿が存在しない
-		return nil, nil
-	} else if searchResult.TotalCount > 1 {
-		// 複数の投稿が存在する
-		return nil, errors.New("複数の日報が存在します")
-	}
-
-	// 最新の投稿を返す
-	return &searchResult.Posts[0], nil
+	return &searchResult, nil
 }
 
 // CreatePost は新しい投稿を作成する
@@ -277,4 +345,122 @@ func updatePost(client *http.Client, config EsaConfig, existingPost *EsaPost, te
 	httpClient := &standardHTTPClient{client: client}
 	esaClient := NewEsaClient(httpClient, config)
 	return esaClient.UpdatePost(existingPost, text)
+}
+
+// WithCategory はカテゴリーの部分一致検索オプションを返す
+func WithCategory(category string) SearchOption {
+	return func(c *searchConfig) {
+		if c.query != "" {
+			c.query += " "
+		}
+		c.query += fmt.Sprintf("category:%s", category)
+	}
+}
+
+// WithCategoryExact はカテゴリーの完全一致検索オプションを返す
+func WithCategoryExact(category string) SearchOption {
+	return func(c *searchConfig) {
+		if c.query != "" {
+			c.query += " "
+		}
+		c.query += fmt.Sprintf("on:%s", category)
+	}
+}
+
+// WithCategoryPrefix はカテゴリーの前方一致検索オプションを返す
+func WithCategoryPrefix(category string) SearchOption {
+	return func(c *searchConfig) {
+		if c.query != "" {
+			c.query += " "
+		}
+		c.query += fmt.Sprintf("in:%s", category)
+	}
+}
+
+// WithTags はタグ検索オプションを返す
+func WithTags(tags ...string) SearchOption {
+	return func(c *searchConfig) {
+		for _, tag := range tags {
+			if c.query != "" {
+				c.query += " "
+			}
+			c.query += fmt.Sprintf("tag:%s", tag)
+		}
+	}
+}
+
+// WithKeywords はキーワード検索オプションを返す
+func WithKeywords(keywords ...string) SearchOption {
+	return func(c *searchConfig) {
+		for _, keyword := range keywords {
+			if c.query != "" {
+				c.query += " "
+			}
+			c.query += keyword
+		}
+	}
+}
+
+// WithUser はユーザー検索オプションを返す
+func WithUser(screenName string) SearchOption {
+	return func(c *searchConfig) {
+		if c.query != "" {
+			c.query += " "
+		}
+		c.query += fmt.Sprintf("user:%s", screenName)
+	}
+}
+
+// WithDateRange は日付範囲検索オプションを返す
+func WithDateRange(field string, from, to time.Time) SearchOption {
+	return func(c *searchConfig) {
+		if !from.IsZero() {
+			if c.query != "" {
+				c.query += " "
+			}
+			c.query += fmt.Sprintf("%s:>%s", field, from.Format("2006-01-02"))
+		}
+		if !to.IsZero() {
+			if c.query != "" {
+				c.query += " "
+			}
+			c.query += fmt.Sprintf("%s:<%s", field, to.Format("2006-01-02"))
+		}
+	}
+}
+
+// WithWIP はWIP状態検索オプションを返す
+func WithWIP(wip bool) SearchOption {
+	return func(c *searchConfig) {
+		if c.query != "" {
+			c.query += " "
+		}
+		c.query += fmt.Sprintf("wip:%t", wip)
+	}
+}
+
+// WithStarred はスター状態検索オプションを返す
+func WithStarred(starred bool) SearchOption {
+	return func(c *searchConfig) {
+		if c.query != "" {
+			c.query += " "
+		}
+		c.query += fmt.Sprintf("starred:%t", starred)
+	}
+}
+
+// WithPagination はページネーションオプションを返す
+func WithPagination(page, perPage int) SearchOption {
+	return func(c *searchConfig) {
+		c.page = page
+		c.perPage = perPage
+	}
+}
+
+// WithSort はソートオプションを返す
+func WithSort(sort, order string) SearchOption {
+	return func(c *searchConfig) {
+		c.sort = sort
+		c.order = order
+	}
 }

--- a/esa_client.go
+++ b/esa_client.go
@@ -11,6 +11,15 @@ import (
 	"time"
 )
 
+const (
+	// esaAPIBaseURL はesa.io APIのベースURL
+	esaAPIBaseURL = "https://api.esa.io/v1"
+	
+	// エンドポイントのパス定義
+	esaPostsEndpoint = "/teams/%s/posts"     // チームの投稿一覧
+	esaPostEndpoint  = "/teams/%s/posts/%d"  // 特定の投稿
+)
+
 // searchConfig は検索オプションを保持する構造体
 type searchConfig struct {
 	query   string
@@ -118,7 +127,7 @@ func (c *EsaClient) Search(options ...SearchOption) (*EsaSearchResult, error) {
 	}
 
 	// URLの構築
-	apiURL := fmt.Sprintf("https://api.esa.io/v1/teams/%s/posts", c.config.TeamName)
+	apiURL := fmt.Sprintf("%s%s", esaAPIBaseURL, fmt.Sprintf(esaPostsEndpoint, c.config.TeamName))
 	
 	// クエリパラメータの構築
 	params := make(map[string]string)
@@ -186,7 +195,7 @@ func (c *EsaClient) CreatePost(text string) (*EsaPost, error) {
 	title := "日報"
 	var tags []string
 
-	url := fmt.Sprintf("https://api.esa.io/v1/teams/%s/posts", c.config.TeamName)
+	url := fmt.Sprintf("%s%s", esaAPIBaseURL, fmt.Sprintf(esaPostsEndpoint, c.config.TeamName))
 
 	// リクエストボディの作成
 	type postRequest struct {
@@ -250,7 +259,7 @@ func (c *EsaClient) CreatePost(text string) (*EsaPost, error) {
 
 // UpdatePost は既存の投稿を更新する
 func (c *EsaClient) UpdatePost(existingPost *EsaPost, text string) (*EsaPost, error) {
-	url := fmt.Sprintf("https://api.esa.io/v1/teams/%s/posts/%d", c.config.TeamName, existingPost.Number)
+	url := fmt.Sprintf("%s%s", esaAPIBaseURL, fmt.Sprintf(esaPostEndpoint, c.config.TeamName, existingPost.Number))
 
 	// リクエストボディの作成
 	type patchRequest struct {

--- a/esa_client_search_test.go
+++ b/esa_client_search_test.go
@@ -1,0 +1,314 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// TestSearch_URLConstruction はSearchメソッドが正しいURLを構築することを検証する
+func TestSearch_URLConstruction(t *testing.T) {
+	tests := []struct {
+		name            string
+		options         []SearchOption
+		expectedURL     string
+		expectedHeaders map[string]string
+	}{
+		{
+			name:    "基本的な検索（オプションなし）",
+			options: []SearchOption{},
+			expectedURL: "https://api.esa.io/v1/teams/test-team/posts?" +
+				"order=desc&page=1&per_page=20&sort=updated",
+			expectedHeaders: map[string]string{
+				"Authorization": "Bearer test-token",
+			},
+		},
+		{
+			name: "カテゴリー検索",
+			options: []SearchOption{
+				WithCategory("日報/2024/12"),
+			},
+			expectedURL: "https://api.esa.io/v1/teams/test-team/posts?" +
+				"order=desc&page=1&per_page=20&q=category%3A%E6%97%A5%E5%A0%B1%2F2024%2F12&sort=updated",
+			expectedHeaders: map[string]string{
+				"Authorization": "Bearer test-token",
+			},
+		},
+		{
+			name: "複数のオプション",
+			options: []SearchOption{
+				WithCategory("日報"),
+				WithTags("golang", "mcp"),
+				WithPagination(2, 50),
+			},
+			expectedURL: "https://api.esa.io/v1/teams/test-team/posts?" +
+				"order=desc&page=2&per_page=50&q=category%3A%E6%97%A5%E5%A0%B1+tag%3Agolang+tag%3Amcp&sort=updated",
+			expectedHeaders: map[string]string{
+				"Authorization": "Bearer test-token",
+			},
+		},
+		{
+			name: "日付範囲検索",
+			options: []SearchOption{
+				WithDateRange("created", 
+					time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+					time.Date(2024, 12, 31, 0, 0, 0, 0, time.UTC),
+				),
+			},
+			expectedURL: "https://api.esa.io/v1/teams/test-team/posts?" +
+				"order=desc&page=1&per_page=20&q=created%3A%3E2024-01-01+created%3A%3C2024-12-31&sort=updated",
+			expectedHeaders: map[string]string{
+				"Authorization": "Bearer test-token",
+			},
+		},
+		{
+			name: "ソート指定",
+			options: []SearchOption{
+				WithSort("created", "asc"),
+			},
+			expectedURL: "https://api.esa.io/v1/teams/test-team/posts?" +
+				"order=asc&page=1&per_page=20&sort=created",
+			expectedHeaders: map[string]string{
+				"Authorization": "Bearer test-token",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// モックHTTPクライアントの作成
+			mockHTTPClient := NewMockHTTPClientInterface(t)
+			
+			// リクエストの検証
+			mockHTTPClient.EXPECT().Do(mock.MatchedBy(func(req *http.Request) bool {
+				// URLの検証
+				actualURL := req.URL.String()
+				
+				// クエリパラメータをパースして比較（順序に依存しない比較）
+				expectedParsed, _ := url.Parse(tt.expectedURL)
+				actualParsed, _ := url.Parse(actualURL)
+				
+				assert.Equal(t, expectedParsed.Scheme, actualParsed.Scheme)
+				assert.Equal(t, expectedParsed.Host, actualParsed.Host)
+				assert.Equal(t, expectedParsed.Path, actualParsed.Path)
+				
+				// クエリパラメータの比較
+				expectedQuery := expectedParsed.Query()
+				actualQuery := actualParsed.Query()
+				assert.Equal(t, expectedQuery, actualQuery)
+				
+				// ヘッダーの検証
+				for key, value := range tt.expectedHeaders {
+					assert.Equal(t, value, req.Header.Get(key))
+				}
+				
+				return true
+			})).Return(&http.Response{
+				StatusCode: 200,
+				Body: io.NopCloser(strings.NewReader(`{
+					"posts": [],
+					"total_count": 0,
+					"page": 1,
+					"per_page": 20,
+					"max_per_page": 100
+				}`)),
+			}, nil)
+
+			// EsaClientの作成とテスト実行
+			config := EsaConfig{
+				TeamName:    "test-team",
+				AccessToken: "test-token",
+			}
+			client := NewEsaClient(mockHTTPClient, config)
+			
+			_, err := client.Search(tt.options...)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+// TestSearch_QueryConstruction は各SearchOptionが正しくクエリを構築することを検証する
+func TestSearch_QueryConstruction(t *testing.T) {
+	tests := []struct {
+		name          string
+		options       []SearchOption
+		expectedQuery string
+	}{
+		{
+			name: "WithCategoryExact",
+			options: []SearchOption{
+				WithCategoryExact("日報/2024/12/20"),
+			},
+			expectedQuery: "on:日報/2024/12/20",
+		},
+		{
+			name: "WithCategoryPrefix",
+			options: []SearchOption{
+				WithCategoryPrefix("日報/2024"),
+			},
+			expectedQuery: "in:日報/2024",
+		},
+		{
+			name: "WithKeywords",
+			options: []SearchOption{
+				WithKeywords("golang", "mcp", "server"),
+			},
+			expectedQuery: "golang mcp server",
+		},
+		{
+			name: "WithUser",
+			options: []SearchOption{
+				WithUser("test_user"),
+			},
+			expectedQuery: "user:test_user",
+		},
+		{
+			name: "WithWIP",
+			options: []SearchOption{
+				WithWIP(true),
+			},
+			expectedQuery: "wip:true",
+		},
+		{
+			name: "WithStarred",
+			options: []SearchOption{
+				WithStarred(false),
+			},
+			expectedQuery: "starred:false",
+		},
+		{
+			name: "複雑な組み合わせ",
+			options: []SearchOption{
+				WithCategory("日報"),
+				WithTags("golang"),
+				WithUser("test_user"),
+				WithWIP(false),
+				WithKeywords("MCP", "サーバー"),
+			},
+			expectedQuery: "category:日報 tag:golang user:test_user wip:false MCP サーバー",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// searchConfigを作成してオプションを適用
+			config := &searchConfig{
+				page:    1,
+				perPage: 20,
+				sort:    "updated",
+				order:   "desc",
+			}
+			
+			for _, opt := range tt.options {
+				opt(config)
+			}
+			
+			assert.Equal(t, tt.expectedQuery, config.query)
+		})
+	}
+}
+
+// TestSearchPostByCategory_BackwardCompatibility は既存メソッドの後方互換性を検証する
+func TestSearchPostByCategory_BackwardCompatibility(t *testing.T) {
+	// モックHTTPクライアントの作成
+	mockHTTPClient := NewMockHTTPClientInterface(t)
+	
+	// 単一の結果を返すケース
+	mockHTTPClient.EXPECT().Do(mock.Anything).Return(&http.Response{
+		StatusCode: 200,
+		Body: io.NopCloser(strings.NewReader(`{
+			"posts": [{
+				"number": 123,
+				"name": "日報",
+				"body_md": "テスト内容",
+				"category": "日報/2024/12/20"
+			}],
+			"total_count": 1,
+			"page": 1,
+			"per_page": 1
+		}`)),
+	}, nil)
+
+	config := EsaConfig{
+		TeamName:    "test-team",
+		AccessToken: "test-token",
+	}
+	client := NewEsaClient(mockHTTPClient, config)
+	
+	post, err := client.SearchPostByCategory("日報/2024/12/20")
+	assert.NoError(t, err)
+	assert.NotNil(t, post)
+	assert.Equal(t, 123, post.Number)
+	assert.Equal(t, "日報", post.Name)
+}
+
+// TestSearch_ErrorHandling はエラーハンドリングを検証する
+func TestSearch_ErrorHandling(t *testing.T) {
+	tests := []struct {
+		name          string
+		statusCode    int
+		responseBody  string
+		expectedError string
+	}{
+		{
+			name:       "APIエラーレスポンス",
+			statusCode: 401,
+			responseBody: `{
+				"error": "unauthorized",
+				"message": "Invalid access token"
+			}`,
+			expectedError: "unauthorized: Invalid access token",
+		},
+		{
+			name:       "不正なJSONレスポンス",
+			statusCode: 200,
+			responseBody: `{invalid json`,
+			expectedError: "検索結果の解析に失敗",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockHTTPClient := NewMockHTTPClientInterface(t)
+			
+			mockHTTPClient.EXPECT().Do(mock.Anything).Return(&http.Response{
+				StatusCode: tt.statusCode,
+				Body:       io.NopCloser(strings.NewReader(tt.responseBody)),
+			}, nil)
+
+			config := EsaConfig{
+				TeamName:    "test-team",
+				AccessToken: "test-token",
+			}
+			client := NewEsaClient(mockHTTPClient, config)
+			
+			_, err := client.Search()
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectedError)
+		})
+	}
+}
+
+// TestSearch_NetworkError はネットワークエラーを検証する
+func TestSearch_NetworkError(t *testing.T) {
+	mockHTTPClient := NewMockHTTPClientInterface(t)
+	
+	mockHTTPClient.EXPECT().Do(mock.Anything).Return(nil, fmt.Errorf("network error"))
+
+	config := EsaConfig{
+		TeamName:    "test-team",
+		AccessToken: "test-token",
+	}
+	client := NewEsaClient(mockHTTPClient, config)
+	
+	_, err := client.Search()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "network error")
+}

--- a/esa_client_search_test.go
+++ b/esa_client_search_test.go
@@ -24,6 +24,11 @@ func buildTestURL(teamName string, queryParams string) string {
 
 // TestSearch_URLConstruction はSearchメソッドが正しいURLを構築することを検証する
 func TestSearch_URLConstruction(t *testing.T) {
+	// 共通のヘッダー
+	commonHeaders := map[string]string{
+		"Authorization": "Bearer test-token",
+	}
+	
 	tests := []struct {
 		name            string
 		options         []SearchOption
@@ -35,9 +40,7 @@ func TestSearch_URLConstruction(t *testing.T) {
 			options: []SearchOption{},
 			expectedURL: buildTestURL("test-team",
 				"order=desc&page=1&per_page=20&sort=updated"),
-			expectedHeaders: map[string]string{
-				"Authorization": "Bearer test-token",
-			},
+			expectedHeaders: commonHeaders,
 		},
 		{
 			name: "カテゴリー検索",
@@ -46,9 +49,7 @@ func TestSearch_URLConstruction(t *testing.T) {
 			},
 			expectedURL: buildTestURL("test-team",
 				"order=desc&page=1&per_page=20&q=category%3A%E6%97%A5%E5%A0%B1%2F2024%2F12&sort=updated"),
-			expectedHeaders: map[string]string{
-				"Authorization": "Bearer test-token",
-			},
+			expectedHeaders: commonHeaders,
 		},
 		{
 			name: "複数のオプション",
@@ -59,9 +60,7 @@ func TestSearch_URLConstruction(t *testing.T) {
 			},
 			expectedURL: buildTestURL("test-team",
 				"order=desc&page=2&per_page=50&q=category%3A%E6%97%A5%E5%A0%B1+tag%3Agolang+tag%3Amcp&sort=updated"),
-			expectedHeaders: map[string]string{
-				"Authorization": "Bearer test-token",
-			},
+			expectedHeaders: commonHeaders,
 		},
 		{
 			name: "日付範囲検索",
@@ -73,9 +72,7 @@ func TestSearch_URLConstruction(t *testing.T) {
 			},
 			expectedURL: buildTestURL("test-team",
 				"order=desc&page=1&per_page=20&q=created%3A%3E2024-01-01+created%3A%3C2024-12-31&sort=updated"),
-			expectedHeaders: map[string]string{
-				"Authorization": "Bearer test-token",
-			},
+			expectedHeaders: commonHeaders,
 		},
 		{
 			name: "ソート指定",
@@ -84,9 +81,7 @@ func TestSearch_URLConstruction(t *testing.T) {
 			},
 			expectedURL: buildTestURL("test-team",
 				"order=asc&page=1&per_page=20&sort=created"),
-			expectedHeaders: map[string]string{
-				"Authorization": "Bearer test-token",
-			},
+			expectedHeaders: commonHeaders,
 		},
 	}
 

--- a/esa_client_search_test.go
+++ b/esa_client_search_test.go
@@ -15,7 +15,7 @@ import (
 
 // buildTestURL はテスト用のAPIエンドポイントURLを構築する
 func buildTestURL(teamName string, queryParams string) string {
-	baseURL := fmt.Sprintf("%s%s", esaAPIBaseURL, fmt.Sprintf(esaPostsEndpoint, teamName))
+	baseURL := fmt.Sprintf("%s"+esaPostsEndpoint, esaAPIBaseURL, teamName)
 	if queryParams != "" {
 		return baseURL + "?" + queryParams
 	}

--- a/esa_client_search_test.go
+++ b/esa_client_search_test.go
@@ -13,6 +13,15 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+// buildTestURL はテスト用のAPIエンドポイントURLを構築する
+func buildTestURL(teamName string, queryParams string) string {
+	baseURL := fmt.Sprintf("%s%s", esaAPIBaseURL, fmt.Sprintf(esaPostsEndpoint, teamName))
+	if queryParams != "" {
+		return baseURL + "?" + queryParams
+	}
+	return baseURL
+}
+
 // TestSearch_URLConstruction はSearchメソッドが正しいURLを構築することを検証する
 func TestSearch_URLConstruction(t *testing.T) {
 	tests := []struct {
@@ -24,8 +33,8 @@ func TestSearch_URLConstruction(t *testing.T) {
 		{
 			name:    "基本的な検索（オプションなし）",
 			options: []SearchOption{},
-			expectedURL: "https://api.esa.io/v1/teams/test-team/posts?" +
-				"order=desc&page=1&per_page=20&sort=updated",
+			expectedURL: buildTestURL("test-team",
+				"order=desc&page=1&per_page=20&sort=updated"),
 			expectedHeaders: map[string]string{
 				"Authorization": "Bearer test-token",
 			},
@@ -35,8 +44,8 @@ func TestSearch_URLConstruction(t *testing.T) {
 			options: []SearchOption{
 				WithCategory("日報/2024/12"),
 			},
-			expectedURL: "https://api.esa.io/v1/teams/test-team/posts?" +
-				"order=desc&page=1&per_page=20&q=category%3A%E6%97%A5%E5%A0%B1%2F2024%2F12&sort=updated",
+			expectedURL: buildTestURL("test-team",
+				"order=desc&page=1&per_page=20&q=category%3A%E6%97%A5%E5%A0%B1%2F2024%2F12&sort=updated"),
 			expectedHeaders: map[string]string{
 				"Authorization": "Bearer test-token",
 			},
@@ -48,8 +57,8 @@ func TestSearch_URLConstruction(t *testing.T) {
 				WithTags("golang", "mcp"),
 				WithPagination(2, 50),
 			},
-			expectedURL: "https://api.esa.io/v1/teams/test-team/posts?" +
-				"order=desc&page=2&per_page=50&q=category%3A%E6%97%A5%E5%A0%B1+tag%3Agolang+tag%3Amcp&sort=updated",
+			expectedURL: buildTestURL("test-team",
+				"order=desc&page=2&per_page=50&q=category%3A%E6%97%A5%E5%A0%B1+tag%3Agolang+tag%3Amcp&sort=updated"),
 			expectedHeaders: map[string]string{
 				"Authorization": "Bearer test-token",
 			},
@@ -62,8 +71,8 @@ func TestSearch_URLConstruction(t *testing.T) {
 					time.Date(2024, 12, 31, 0, 0, 0, 0, time.UTC),
 				),
 			},
-			expectedURL: "https://api.esa.io/v1/teams/test-team/posts?" +
-				"order=desc&page=1&per_page=20&q=created%3A%3E2024-01-01+created%3A%3C2024-12-31&sort=updated",
+			expectedURL: buildTestURL("test-team",
+				"order=desc&page=1&per_page=20&q=created%3A%3E2024-01-01+created%3A%3C2024-12-31&sort=updated"),
 			expectedHeaders: map[string]string{
 				"Authorization": "Bearer test-token",
 			},
@@ -73,8 +82,8 @@ func TestSearch_URLConstruction(t *testing.T) {
 			options: []SearchOption{
 				WithSort("created", "asc"),
 			},
-			expectedURL: "https://api.esa.io/v1/teams/test-team/posts?" +
-				"order=asc&page=1&per_page=20&sort=created",
+			expectedURL: buildTestURL("test-team",
+				"order=asc&page=1&per_page=20&sort=created"),
 			expectedHeaders: map[string]string{
 				"Authorization": "Bearer test-token",
 			},

--- a/mocks_test.go
+++ b/mocks_test.go
@@ -179,7 +179,13 @@ func (_mock *MockEsaClientInterface) UpdatePost(existingPost *EsaPost, text stri
 
 // Search provides a mock function for the type MockEsaClientInterface
 func (_mock *MockEsaClientInterface) Search(options ...SearchOption) (*EsaSearchResult, error) {
-	ret := _mock.Called(options)
+	_va := make([]interface{}, len(options))
+	for _i := range options {
+		_va[_i] = options[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _va...)
+	ret := _mock.Called(_ca...)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Search")
@@ -218,7 +224,13 @@ func (_e *MockEsaClientInterface_Expecter) Search(options interface{}) *MockEsaC
 
 func (_c *MockEsaClientInterface_Search_Call) Run(run func(options ...SearchOption)) *MockEsaClientInterface_Search_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].([]SearchOption)...)
+		variadicArgs := make([]SearchOption, len(args))
+		for i, a := range args {
+			if a != nil {
+				variadicArgs[i] = a.(SearchOption)
+			}
+		}
+		run(variadicArgs...)
 	})
 	return _c
 }

--- a/mocks_test.go
+++ b/mocks_test.go
@@ -177,6 +177,62 @@ func (_mock *MockEsaClientInterface) UpdatePost(existingPost *EsaPost, text stri
 	return r0, r1
 }
 
+// Search provides a mock function for the type MockEsaClientInterface
+func (_mock *MockEsaClientInterface) Search(options ...SearchOption) (*EsaSearchResult, error) {
+	ret := _mock.Called(options)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Search")
+	}
+
+	var r0 *EsaSearchResult
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(...SearchOption) (*EsaSearchResult, error)); ok {
+		return returnFunc(options...)
+	}
+	if returnFunc, ok := ret.Get(0).(func(...SearchOption) *EsaSearchResult); ok {
+		r0 = returnFunc(options...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*EsaSearchResult)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(...SearchOption) error); ok {
+		r1 = returnFunc(options...)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockEsaClientInterface_Search_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Search'
+type MockEsaClientInterface_Search_Call struct {
+	*mock.Call
+}
+
+// Search is a helper method to define mock.On call
+//   - options
+func (_e *MockEsaClientInterface_Expecter) Search(options interface{}) *MockEsaClientInterface_Search_Call {
+	return &MockEsaClientInterface_Search_Call{Call: _e.mock.On("Search", options)}
+}
+
+func (_c *MockEsaClientInterface_Search_Call) Run(run func(options ...SearchOption)) *MockEsaClientInterface_Search_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].([]SearchOption)...)
+	})
+	return _c
+}
+
+func (_c *MockEsaClientInterface_Search_Call) Return(result *EsaSearchResult, err error) *MockEsaClientInterface_Search_Call {
+	_c.Call.Return(result, err)
+	return _c
+}
+
+func (_c *MockEsaClientInterface_Search_Call) RunAndReturn(run func(...SearchOption) (*EsaSearchResult, error)) *MockEsaClientInterface_Search_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // MockEsaClientInterface_UpdatePost_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdatePost'
 type MockEsaClientInterface_UpdatePost_Call struct {
 	*mock.Call


### PR DESCRIPTION
## 概要
esa.io APIの検索機能を一般化し、より柔軟な検索オプションを提供できるようにしました。

## 変更内容

### 機能的オプションパターンの採用
- `SearchOption`型と`searchConfig`構造体を定義
- `WithCategory`, `WithTags`, `WithDateRange`等の各種オプション関数を実装
- 汎用的な`Search`メソッドを実装

### APIエンドポイントの定数化
- `esaAPIBaseURL`とエンドポイントパスを定数として定義
- プロダクションコードとテストコードで同じ定数を参照するように修正

### 検索オプション
以下の検索オプションをサポート：
- カテゴリー検索（部分一致、前方一致、完全一致）
- タグ検索
- キーワード検索
- ユーザー検索
- 日付範囲検索
- WIP/スター状態での絞り込み
- ページネーション
- ソート条件

### 後方互換性
- 既存の`SearchPostByCategory`メソッドは内部で新しい`Search`メソッドを使用
- APIの振る舞いは変更なし

## 使用例

```go
// 日報検索（既存の使い方）
post, err := client.SearchPostByCategory("日報/2024/12/20")

// 汎用検索の例
results, err := client.Search(
    WithCategory("日報"),
    WithDateRange("created", startDate, endDate),
    WithTags("golang", "mcp"),
    WithPagination(1, 50),
)

// 完全一致でのカテゴリー検索
results, err := client.Search(
    WithCategoryExact("日報/2024/12/20"),
)
```

## テスト
- APIリクエストの構築を検証するテストを追加
- 各SearchOptionの動作を検証
- エラーハンドリングのテストを追加
- 後方互換性の確認テストを追加

🤖 Generated with [Claude Code](https://claude.ai/code)